### PR TITLE
Fix build matrix (gcc8 is missing)

### DIFF
--- a/.github/workflows/generateRelease.yml
+++ b/.github/workflows/generateRelease.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         config:
           - { name: "Windows MSVC", suffix: "Windows", os: windows-latest, cc: "cl.exe", cxx: "cl.exe" }
-          - { name: "Ubuntu gcc", suffix: "Linux-gcc8", os: ubuntu-18.04, cc: "gcc-8", cxx: "g++-8" }
-          - { name: "Ubuntu gcc", suffix: "Linux-gcc10", os: ubuntu-20.04, cc: "gcc-10", cxx: "g++-10" }
+          - { name: "Ubuntu 18.04 gcc9", suffix: "Linux-gcc9", os: ubuntu-18.04, cc: "gcc-9", cxx: "g++-9" }
+          - { name: "Ubuntu 20.04 gcc10", suffix: "Linux-gcc10", os: ubuntu-20.04, cc: "gcc-10", cxx: "g++-10" }
           - { name: "MacOS clang", suffix: "macOS", os: macos-latest, cc: "clang", cxx: "clang++" }
 
     steps:       
@@ -159,8 +159,8 @@ jobs:
       matrix:
         config:
           - { name: "Windows MSVC", suffix: "Windows", os: windows-latest, cc: "cl.exe", cxx: "cl.exe" }
-          - { name: "Ubuntu gcc", suffix: "Linux-gcc8", os: ubuntu-18.04, cc: "gcc-8", cxx: "g++-8" }
-          - { name: "Ubuntu gcc", suffix: "Linux-gcc10", os: ubuntu-20.04, cc: "gcc-10", cxx: "g++-10" }
+          - { name: "Ubuntu 18.04 gcc9", suffix: "Linux-gcc9", os: ubuntu-18.04, cc: "gcc-9", cxx: "g++-9" }
+          - { name: "Ubuntu 20.04 gcc10", suffix: "Linux-gcc10", os: ubuntu-20.04, cc: "gcc-10", cxx: "g++-10" }
           - { name: "MacOS clang", suffix: "macOS", os: macos-latest, cc: "clang", cxx: "clang++" }
 
     steps:


### PR DESCRIPTION
Replace gcc8 by gcc9
Also change names on ubuntu to disambiguate between 18.04 and 20.04